### PR TITLE
#114 caret position variable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,16 @@ Contact:
 
 TODO: Add FelipeRearden, skipadu and vrajur
 
+
+## Vinay Rajur
+ - Contributor
+ - Testing
+ - Documentation
+ - Ideas and Feedback
+
+Contact:
+ - https://github.com/vrajur
+
 <!-- ADDING YOURSELF AS AN AUTHOR:
 
 1. Add a new headline above this comment block: ## Firstname Lastname (or you can use a nick name if you wish).

--- a/src/variables/ShellCommandVariable_CaretPosition.ts
+++ b/src/variables/ShellCommandVariable_CaretPosition.ts
@@ -1,0 +1,98 @@
+import {getEditor} from "../Common";
+import {addShellCommandVariableInstructions} from "./ShellCommandVariableInstructions";
+import {IParameters, ShellCommandVariable} from "./ShellCommandVariable";
+import {IAutocompleteItem} from "../settings/setting_elements/Autocomplete";
+
+export class ShellCommandVariable_CaretPosition extends ShellCommandVariable {
+    static variable_name = "caret_position";
+    static help_text = "Gives the line number and column position of the current caret position as 'line:column'. Get only the line number using {{caret_position:line}}, and only the column with {{caret_position:column}}. Line and column numbers are 1-indexed.";
+
+    protected static readonly parameters: IParameters = {
+        mode: {
+            options: ["line", "column"],
+            required: false,
+        },
+    };
+
+    protected arguments: {
+        mode: string;
+    }
+
+    generateValue(): string {
+        // Check that we are able to get an editor
+        const editor = getEditor(this.app);
+        if (null === editor) {
+            // Nope.
+            this.newErrorMessage("Could not get an editor instance! Please raise an issue in GitHub.");
+            return null;
+        }
+
+        const position = editor.getCursor('to');
+        const line = position.line + 1; // editor position is zero-indexed, line numbers are 1-indexed
+        const column = position.ch + 1; // editor position is zero-indexed, column positions are 1-indexed
+        
+        if (Object.keys(this.arguments).length > 0) {
+            switch (this.arguments.mode.toLowerCase()) {
+                case "line":
+                    return `${line}`;
+                case "column":
+                    return `${column}`;
+                default:
+                    this.newErrorMessage("Unrecognised argument: "+this.arguments.mode);
+                    return null;
+            }
+        } else {
+            // default case when no args provided
+            return `${line}:${column}`;
+        }
+    }
+
+    public static getAutocompleteItems() {
+        return [
+            // Normal variables
+            <IAutocompleteItem>{
+                value: "{{" + this.variable_name + "}}",
+                help_text: "Gives the line number and column position of the current caret position as 'line:column'.",
+                group: "Variables",
+                type: "normal-variable"
+            },
+            <IAutocompleteItem>{
+                value: "{{" + this.variable_name + ":line}}",
+                help_text: "Gives the line number of the current caret position.",
+                group: "Variables",
+                type: "normal-variable"
+            },
+            <IAutocompleteItem>{
+                value: "{{" + this.variable_name + ":column}}",
+                help_text: "Gives the column number of the current caret position.",
+                group: "Variables",
+                type: "normal-variable"
+            },
+
+            // Unescaped variables
+            <IAutocompleteItem>{
+                value: "{{!" + this.variable_name + "}}",
+                help_text: "Gives the line number and column position of the current caret position as 'line:column'.",
+                group: "Variables",
+                type: "unescaped-variable",
+            },
+            <IAutocompleteItem>{
+                value: "{{!" + this.variable_name + ":line}}",
+                help_text: "Gives the line number of the current caret position.",
+                group: "Variables",
+                type: "unescaped-variable",
+            },
+            <IAutocompleteItem>{
+                value: "{{!" + this.variable_name + ":column}}",
+                help_text: "Gives the column number of the current caret position.",
+                group: "Variables",
+                type: "unescaped-variable",
+            },
+        ];
+    }
+}
+
+addShellCommandVariableInstructions(
+    "{{caret_position}}, {{caret_position:line}} or {{caret_position:column}}",
+    ShellCommandVariable_CaretPosition.help_text,
+);

--- a/src/variables/VariableLists.ts
+++ b/src/variables/VariableLists.ts
@@ -1,5 +1,6 @@
 import {ShellCommandVariable} from "./ShellCommandVariable";
 import {ShellCommandVariable_Clipboard} from "./ShellCommandVariable_Clipboard";
+import {ShellCommandVariable_CaretPosition} from "./ShellCommandVariable_CaretPosition";
 import {ShellCommandVariable_Date} from "./ShellCommandVariable_Date";
 import {ShellCommandVariable_FileName} from "./ShellCommandVariable_FileName";
 import {ShellCommandVariable_FilePath} from "./ShellCommandVariable_FilePath";
@@ -17,6 +18,7 @@ import ShellCommandsPlugin from "../main";
 export function getVariables(plugin: ShellCommandsPlugin, shell: string) {
     let shell_command_variables: ShellCommandVariable[] = [
         new ShellCommandVariable_Clipboard(plugin, shell),
+        new ShellCommandVariable_CaretPosition(plugin, shell),
         new ShellCommandVariable_Date(plugin, shell),
         new ShellCommandVariable_FileName(plugin, shell),
         new ShellCommandVariable_FilePath(plugin, shell),
@@ -40,6 +42,7 @@ export function getVariables(plugin: ShellCommandsPlugin, shell: string) {
 export function getVariableClasses() {
     let shell_command_variables = [
         ShellCommandVariable_Clipboard,
+        ShellCommandVariable_CaretPosition,
         ShellCommandVariable_Date,
         ShellCommandVariable_FileName,
         ShellCommandVariable_FilePath,


### PR DESCRIPTION
# Description
Adds a new variable `caret_position` to the list of supported variables for the shell command plugin. This PR is current with development in the `0.8.0` branch. 

Change Type: New Feature

See related discussion in #114 