### PR TITLE
adding a special case, where an object, which is an array of strings …

### DIFF
--- a/src/variables/VariableHelpers.ts
+++ b/src/variables/VariableHelpers.ts
@@ -197,6 +197,11 @@ export function getFileYAMLValue(app: App, file: TFile, property_path: string) {
             // Check if we have still dot notation parts left in the property path.
             if (0 === property_parts.length) {
                 // No dot notation parts are left.
+                const maybeJoinedStrings = joinStringsIfArray(property_value);
+                if (null !== maybeJoinedStrings) {
+                    // The object was an array of strings. Join them together.
+                    return maybeJoinedStrings;
+                }
                 // Freak out.
                 const nested_elements_keys = Object.getOwnPropertyNames(property_value);
                 if (nested_elements_keys.length > 0) {
@@ -220,4 +225,16 @@ export function getFileYAMLValue(app: App, file: TFile, property_path: string) {
         }
     }
 
+}
+
+function isArrayofStrings(obj: any): obj is string[] {
+    return Array.isArray(obj) && obj.every(item => typeof item === 'string');
+}
+
+function joinStringsIfArray(obj: any): string | null {
+    if (isArrayofStrings(obj)) {
+        return obj.join(' ');
+    } else {
+        return null;
+    }
 }


### PR DESCRIPTION
…can be accessed as a single variable, and the strings will be returned as space joined string.

This addresses https://github.com/Taitava/obsidian-shellcommands/discussions/415

It is a change to the code that fetches variables from YAML frontmatter.   In my use case, I would like to use a single YAML property, which contains an ordered list of strings to generate multiple shell parameters:

```
my-property:
  - foo
  - bar
  - baz
```

In the current code, the function chain returns a single `string` when successful, and a `[]string` of errors when it fails.  To accomplish this case, I wait until the last possible moment: right before "Freak out." and make a final check if the object is, in fact, an array of all strings.  If it is, I concatenate them with a space separator, and return them as a single string.

There is a small problem that the space separators are escaped, causing the shell arguments to be interpreted as a single, long argument, but by using the `{{!property_value}}` notation, it can still be worked around. This has the undesirable side effect/corner case that, if individual members of the list contain spaces, they must manually escaped.