### PR TITLE
Add shell: sh

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,6 +54,14 @@ Contact:
 Contact:
 - https://github.com/jvsteiner
 
+## Jon Erling Hustadnes
+- Contributor:
+   - Adding shell (`/bin/sh`)
+- Ideas and feedback
+
+Contact:
+- http://github.com/husjon
+
 <!-- ADDING YOURSELF AS AN AUTHOR:
 
 1. Add a new headline above this comment block: ## Firstname Lastname (or you can use a nick name if you wish).

--- a/src/shells/ShellFunctions.ts
+++ b/src/shells/ShellFunctions.ts
@@ -23,6 +23,7 @@ import {Shell} from "./Shell";
 import {Shell_Bash} from "./Shell_Bash";
 import {Shell_Dash} from "./Shell_Dash";
 import {Shell_Zsh} from "./Shell_Zsh";
+import {Shell_Sh} from "./Shell_Sh";
 import {Shell_PowerShellCore} from "./Shell_PowerShellCore";
 import {Shell_PowerShell5} from "./Shell_PowerShell5";
 import {Shell_CMD} from "./Shell_CMD";
@@ -37,6 +38,7 @@ export function registerBuiltinShells(plugin: SC_Plugin) {
     registerShell(new Shell_Bash(plugin));
     registerShell(new Shell_Dash(plugin));
     registerShell(new Shell_Zsh(plugin));
+    registerShell(new Shell_Sh(plugin));
     registerShell(new Shell_PowerShellCore(plugin));
     registerShell(new Shell_PowerShell5(plugin));
     registerShell(new Shell_CMD(plugin));

--- a/src/shells/Shell_Bash.ts
+++ b/src/shells/Shell_Bash.ts
@@ -25,7 +25,6 @@ import {BuiltinShell} from "./BuiltinShell";
 export class Shell_Bash extends BuiltinShell {
     protected ownedShellBinaries = [
         "bash",
-        "sh", // Sh might be something else than Bash, too, but make at least some Shell_* class recognise it. // TODO: Need to test that this works.
     ];
 
     protected getEscaper(rawValue: string): ShEscaper {

--- a/src/shells/Shell_Sh.ts
+++ b/src/shells/Shell_Sh.ts
@@ -1,0 +1,60 @@
+/*
+ * 'Shell commands' plugin for Obsidian.
+ * Copyright (C) 2021 - 2024 Jarkko Linnanvirta
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.0 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact the author (Jarkko Linnanvirta): https://github.com/Taitava/
+ */
+
+import {PlatformId} from "../settings/SC_MainSettings";
+import {normalizePath2} from "../Common";
+import {ShEscaper} from "../variables/escapers/ShEscaper";
+import {BuiltinShell} from "./BuiltinShell";
+
+export class Shell_Sh extends BuiltinShell {
+    protected ownedShellBinaries = [
+        "sh"
+    ];
+
+    protected getEscaper(rawValue: string): ShEscaper {
+        return new ShEscaper(rawValue);
+    }
+
+    public getName(): string {
+        return "Sh";
+    }
+
+    public getBinaryPath(): string {
+        return "/bin/sh";
+    }
+
+    public getSupportedHostPlatforms(): PlatformId[] {
+        return [
+            "darwin", // macOS
+            "linux",
+        ];
+    }
+
+    public getPathSeparator(): ":" {
+        return ":";
+    }
+
+    public translateAbsolutePath(originalPath: string): string {
+        return normalizePath2(originalPath, false);
+    }
+
+    public translateRelativePath(originalPath: string): string {
+        return normalizePath2(originalPath, false);
+    }
+}


### PR DESCRIPTION
The `sh` reference in [Shell_Bash.ts#L28](https://github.com/Taitava/obsidian-shellcommands/blob/main/src/shells/Shell_Bash.ts#L28) unfortunately does not work, in particular on NixOS which does not use traditional [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard), as such the only way to spawn a shell without knowing the path is to use `/usr/bin/env bash` or `/usr/bin/env zsh` etc.
Since this was not possible to add quickly, I instead decided to add a separate Shell for `/bin/sh` which is available (also on most if not all Linux distros and MacOS).

In short, this PR moves the `sh` reference to a separate Shell (`Shell_Sh.ts`) to allow it to be selected separately.