### PR TITLE
Fix blank settings tabs on Obsidian 1.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Features that are currently in development and not released yet. This does not i
 ### To be Changed
  - [Updated copyright year to 2025 (#199)](https://github.com/Taitava/obsidian-shellcommands/issues/199).
 
+### Fixed
+ - Settings tabs blank on Obsidian 1.13+: activate tab panes via the in-memory container map / container-scoped lookup instead of `document.getElementById()`, so `.SC-tab-active` is applied to the visible pane and the Shell commands list / New shell command button render again.
+
 ## [0.23.0] - 2024-11-09
 
 ### Added

--- a/src/settings/setting_elements/Tabs.ts
+++ b/src/settings/setting_elements/Tabs.ts
@@ -122,14 +122,25 @@ export function createTabs(container_element: HTMLElement, tabs: Tabs, activateT
                 throw new Error("Tab button has no 'activateTab' HTML attribute! Murr!");
             }
             const activate_tab_id = activateTabAttribute.value;
-            const tab_content: HTMLElement | null = document.getElementById(activate_tab_id);
+            // Prefer the in-memory container map (and container-scoped DOM lookup) over
+            // document.getElementById(). On Obsidian 1.13+ settings panes, getElementById
+            // often returns null for these tab nodes, so .SC-tab-active never sticks and
+            // CSS keeps .SC-tab-content { display: none } — empty settings UI except the
+            // footer links that live outside the tab system.
+            const logical_tab_id = activate_tab_id.replace(/^SC-tab-/, "");
+            const tab_content: HTMLElement | null =
+                tab_content_containers[logical_tab_id]
+                ?? (typeof container_element.find === "function"
+                    ? container_element.find("#" + activate_tab_id)
+                    : null)
+                ?? container_element.querySelector("#" + activate_tab_id);
             if (null === tab_content) {
                 throw new Error("No tab content was found with activate_tab_id '"+activate_tab_id+"'! Hmph!");
             }
             tab_content.addClass("SC-tab-active");
 
             // Mark the clicked tab as active in TabStructure (just to report which tab is currently active)
-            tab_structure.active_tab_id = activate_tab_id.replace(/^SC-tab-/, ""); // Remove "SC-tab" prefix.
+            tab_structure.active_tab_id = logical_tab_id;
 
             // Focus an element (if a focusable element is present)
             tab_content.find(".SC-focus-element-on-tab-opening")?.focus(); // ? = If not found, do nothing.


### PR DESCRIPTION
## Summary
- On Obsidian **1.13.x**, the Shell commands settings view showed tab headers and the documentation/copyright footer, but the active tab body (search field, command list, **New shell command** button) was missing — with no DevTools console errors.
- Root cause: tab visibility depends on `.SC-tab-content.SC-tab-active { display: block }`, while inactive panes use `.SC-tab-content { display: none }`. Activation used `document.getElementById(activate_tab_id)`, which returns **null** for these nodes in the Obsidian 1.13 settings pane, so `.SC-tab-active` never stuck on the visible content.
- Fix: resolve the tab pane from the in-memory `tab_content_containers` map (with container-scoped `find` / `querySelector` fallback) instead of `document.getElementById`.

Fixes #483
Related: #467

## What I observed
1. Plugin **0.23.0** enabled; settings tab opened with only header buttons + footer links.
2. No console errors.
3. Runtime instrumentation showed `tabShellCommands` **did** build the UI (`Search shell commands`, `New shell command`, childCount 4), but after `createTabs` activation `activeCount` was **0** (no `.SC-tab-active` on any pane).
4. After switching activation to container-scoped lookup: `activeCount: 1`, computed `display: block`, button visible. Direct measurement: `document.getElementById(SC-tab-main-shell-commands)` was still **null** while the container map / scoped query found the live node.

## Test plan
- [ ] On Obsidian **1.13.x**, open Settings → Community plugins → Shell commands.
- [ ] Confirm the Shell commands tab shows search, empty-state text (or existing commands), and **New shell command**.
- [ ] Click Environments / Preactions / Output / Events / Variables and confirm each tab body appears.
- [ ] Create a shell command, close settings, reopen, confirm it still lists.
- [ ] Smoke on an older Obsidian (e.g. 1.7.x) if available: settings tabs still switch normally.