### PR TITLE
Keep permanent/if-long execution notices until process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Mind the order!
 Features that are currently in development and not released yet. This does not include features that require longer planning, for which please see the [Roadmap](https://publish.obsidian.md/shellcommands/Roadmap) and [Ideas](https://github.com/Taitava/obsidian-shellcommands/discussions/categories/ideas) sections.
 
 ### To be Fixed
- - Execution notification modes _Show until the process is finished_ and _Show only if executing takes long_: do not dismiss the balloon when the notice body is clicked; keep it until the process exits (terminate control still works). Related pull request will reference the feature-request issue.
+ - [Execution notification modes _Show until the process is finished_ and _Show only if executing takes long_: do not dismiss the balloon when the notice body is clicked; keep it until the process exits (terminate control still works) (#484)](https://github.com/Taitava/obsidian-shellcommands/issues/484).
 
 ### To be Changed
  - [Updated copyright year to 2025 (#199)](https://github.com/Taitava/obsidian-shellcommands/issues/199).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Mind the order!
 ## [Unreleased]
 Features that are currently in development and not released yet. This does not include features that require longer planning, for which please see the [Roadmap](https://publish.obsidian.md/shellcommands/Roadmap) and [Ideas](https://github.com/Taitava/obsidian-shellcommands/discussions/categories/ideas) sections.
 
+### To be Fixed
+ - Execution notification modes _Show until the process is finished_ and _Show only if executing takes long_: do not dismiss the balloon when the notice body is clicked; keep it until the process exits (terminate control still works). Related pull request will reference the feature-request issue.
+
 ### To be Changed
  - [Updated copyright year to 2025 (#199)](https://github.com/Taitava/obsidian-shellcommands/issues/199).
 

--- a/src/ShellCommandExecutor.ts
+++ b/src/ShellCommandExecutor.ts
@@ -528,6 +528,37 @@ export class ShellCommandExecutor {
             }
         };
 
+        /**
+         * Obsidian Notices with duration 0 stay until the user clicks them. For process-lifetime
+         * "Executing…" notices, block body-click dismiss so the balloon matches
+         * "Show until the process is finished". The terminate control is exempt.
+         */
+        const makeExecutionNoticeSticky = (notice: Notice) => {
+            const guard = (event: Event) => {
+                const target = event.target;
+                if (target instanceof Element && target.closest(".SC-icon-terminate-process")) {
+                    return;
+                }
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            };
+            const elements: HTMLElement[] = [];
+            // @ts-ignore Notice.noticeEl / containerEl: private or version-gated Obsidian API.
+            const noticeEl = notice.noticeEl;
+            if (undefined !== noticeEl && noticeEl instanceof HTMLElement) {
+                elements.push(noticeEl);
+            }
+            // @ts-ignore Notice.containerEl since Obsidian 1.8.7.
+            const containerEl = notice.containerEl;
+            if (undefined !== containerEl && containerEl instanceof HTMLElement && !elements.includes(containerEl)) {
+                elements.push(containerEl);
+            }
+            for (const el of elements) {
+                el.addEventListener("click", guard, true);
+                el.addEventListener("pointerdown", guard, true);
+            }
+        };
+
         const execution_notification_message = "Executing: " + (this.t_shell_command.getAlias() || shell_command);
         switch (execution_notification_mode) {
             case "quick": {
@@ -540,6 +571,7 @@ export class ShellCommandExecutor {
                 // Show the notification until the process ends.
                 const processNotification = this.plugin.newNotification(execution_notification_message, 0);
                 createRequestTerminatingButton(processNotification);
+                makeExecutionNoticeSticky(processNotification);
 
                 // Hide the notification when the process finishes.
                 child_process.on("exit", () => processNotification.hide());
@@ -554,6 +586,7 @@ export class ShellCommandExecutor {
                         // Display notification.
                         const processNotification = this.plugin.newNotification(execution_notification_message, 0);
                         createRequestTerminatingButton(processNotification);
+                        makeExecutionNoticeSticky(processNotification);
 
                         // Hide the notification when the process finishes.
                         child_process.on("exit", () => processNotification.hide());


### PR DESCRIPTION
## Summary

- For execution notification modes **Show until the process is finished** (`permanent`) and **Show only if executing takes long** (`if-long`), block Obsidian Notice body-click dismiss while the process is still running.
- Terminate (power) control remains clickable; notice still auto-hides on process `exit`.
- `quick` mode unchanged.

Fixes #484

## Why

Obsidian `Notice` with `duration = 0` means "until the user dismisses it." Shell commands already hide on `exit`, but a click still dismisses the balloon immediately, which contradicts the setting label for long-running commands.

## Test plan

- [ ] Set a shell command to **Show until the process is finished**, run a command that sleeps ~30s.
- [ ] Click the **Executing…** notice body — balloon should stay visible.
- [ ] Confirm power/terminate control still requests termination.
- [ ] Confirm notice disappears when the process exits normally.
- [ ] Repeat with **Show only if executing takes long** (notice appears after ~2s).
- [ ] Confirm **Show for N seconds** (`quick`) still dismisses on click / timeout as before.
