### PR TITLE
Add Terminate process tree setting (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Mind the order!
 ## [Unreleased]
 Features that are currently in development and not released yet. This does not include features that require longer planning, for which please see the [Roadmap](https://publish.obsidian.md/shellcommands/Roadmap) and [Ideas](https://github.com/Taitava/obsidian-shellcommands/discussions/categories/ideas) sections.
 
+### To be Added
+ - Per shell command setting _Terminate process tree_ (default off). When enabled, the terminate (power) control kills the spawn and its descendants on Windows via `taskkill /F /T` so nested children (e.g. powershell → agent) do not keep running after SIGTERM on the top-level process only. Related pull request will reference the feature-request issue.
+
 ### To be Changed
  - [Updated copyright year to 2025 (#199)](https://github.com/Taitava/obsidian-shellcommands/issues/199).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Mind the order!
 Features that are currently in development and not released yet. This does not include features that require longer planning, for which please see the [Roadmap](https://publish.obsidian.md/shellcommands/Roadmap) and [Ideas](https://github.com/Taitava/obsidian-shellcommands/discussions/categories/ideas) sections.
 
 ### To be Added
- - Per shell command setting _Terminate process tree_ (default off). When enabled, the terminate (power) control kills the spawn and its descendants on Windows via `taskkill /F /T` so nested children (e.g. powershell → agent) do not keep running after SIGTERM on the top-level process only. Related pull request will reference the feature-request issue.
+ - [Per shell command setting _Terminate process tree_ (default off). When enabled, the terminate (power) control kills the spawn and its descendants on Windows via `taskkill /F /T` so nested children (e.g. powershell → agent) do not keep running after SIGTERM on the top-level process only (#486)](https://github.com/Taitava/obsidian-shellcommands/issues/486).
 
 ### To be Changed
  - [Updated copyright year to 2025 (#199)](https://github.com/Taitava/obsidian-shellcommands/issues/199).

--- a/src/ShellCommandExecutor.ts
+++ b/src/ShellCommandExecutor.ts
@@ -19,6 +19,7 @@
 
 import {
     ChildProcess,
+    execFile,
 } from "child_process";
 import {
     cloneObject,
@@ -297,6 +298,21 @@ export class ShellCommandExecutor {
 
                 // Define a terminator
                 const processTerminator = () => {
+                    const pid = child_process.pid;
+                    if (
+                        this.t_shell_command.getTerminateProcessTree()
+                        && undefined !== pid
+                        && "win32" === process.platform
+                    ) {
+                        // Kill the spawn and all descendants (cmd → powershell → node, etc.).
+                        execFile("taskkill", ["/F", "/T", "/PID", String(pid)], (error) => {
+                            if (error) {
+                                debugLog("taskkill /T failed, falling back to SIGTERM: " + error.message);
+                                child_process.kill("SIGTERM");
+                            }
+                        });
+                        return;
+                    }
                     child_process.kill("SIGTERM");
                 };
                 

--- a/src/TShellCommand.ts
+++ b/src/TShellCommand.ts
@@ -288,6 +288,13 @@ export class TShellCommand extends Cacheable {
         return this.configuration.confirm_execution;
     }
 
+    /**
+     * Missing/undefined in older settings files → false (default off).
+     */
+    public getTerminateProcessTree(): boolean {
+        return true === this.configuration.terminate_process_tree;
+    }
+
     public getIgnoreErrorCodes() {
         return this.configuration.ignore_error_codes;
     }

--- a/src/settings/ShellCommandConfiguration.ts
+++ b/src/settings/ShellCommandConfiguration.ts
@@ -49,6 +49,11 @@ export interface ShellCommandConfiguration {
     alias: string;
     icon: string | null;
     confirm_execution: boolean;
+    /**
+     * When true, the "Request to terminate the process" control kills the spawned process and its descendants
+     * (Windows: taskkill /T). Default false keeps child_process.kill("SIGTERM") on the top-level spawn only.
+     */
+    terminate_process_tree: boolean;
     ignore_error_codes: number[];
     input_contents: {
         stdin: string | null,
@@ -87,6 +92,7 @@ export function newShellCommandConfiguration(shell_command_id: string, shell_com
         alias: "",
         icon: null,
         confirm_execution: false,
+        terminate_process_tree: false,
         ignore_error_codes: [],
         input_contents: {
             stdin: null,

--- a/src/settings/ShellCommandSettingsModal.ts
+++ b/src/settings/ShellCommandSettingsModal.ts
@@ -277,6 +277,19 @@ export class ShellCommandSettingsModal extends SC_Modal {
             )
         ;
 
+        // Terminate process tree (default off — SIGTERM only hits the top-level spawn on Windows)
+        new Setting(container_element)
+            .setName("Terminate process tree")
+            .setDesc("When requesting terminate (power icon), also kill child processes of the shell command. Off by default. Enable for commands that spawn long-lived children (e.g. nested powershell or agent). On Windows uses taskkill /F /T.")
+            .addToggle(toggle => toggle
+                .setValue(this.t_shell_command.getTerminateProcessTree())
+                .onChange(async (value) => {
+                    this.t_shell_command.getConfiguration().terminate_process_tree = value;
+                    await this.plugin.saveSettings();
+                })
+            )
+        ;
+
         // Stdin field
         new Setting(container_element)
             .setName("Pass variables to standard input (stdin) (experimental)")


### PR DESCRIPTION
## Summary

- Add per shell command setting **Terminate process tree** (default **off**).
- When enabled on Windows, the power / terminate control runs `taskkill /F /T /PID <spawn>` so nested children die with the command.
- When off (default), behavior is unchanged: `child_process.kill("SIGTERM")` on the top-level spawn only.

Fixes #486

## Why default off

Tree-kill is more aggressive than SIGTERM. Existing commands keep current behavior unless they opt in.

## Test plan

- [ ] New/updated shell command: setting **Terminate process tree** appears; default is off.
- [ ] Flag **off**: run a command that starts a nested long-lived child; terminate → confirm historical behavior (top process dies; children may remain).
- [ ] Flag **on** (Windows): same command; terminate → `cmd` / `powershell` / nested `node` (or similar) all exit.
- [ ] Flag **on** but `taskkill` fails: falls back to SIGTERM.
- [ ] Non-Windows: flag on still uses SIGTERM (documented Windows-first).
